### PR TITLE
Prevent submission of duplicate items to the Entertainment Item Dashboard

### DIFF
--- a/src/main/java/com/google/ehub/data/EntertainmentItem.java
+++ b/src/main/java/com/google/ehub/data/EntertainmentItem.java
@@ -21,10 +21,11 @@ public final class EntertainmentItem {
   private final String directors;
   private final String writers;
   private final String actors;
+  private final String omdbId;
 
   private EntertainmentItem(Optional<Long> uniqueId, String title, String description,
       String imageUrl, String releaseDate, String runtime, String genre, String directors,
-      String writers, String actors) {
+      String writers, String actors, String omdbId) {
     this.uniqueId = uniqueId;
     this.title = title;
     this.description = description;
@@ -35,6 +36,7 @@ public final class EntertainmentItem {
     this.directors = directors;
     this.writers = writers;
     this.actors = actors;
+    this.omdbId = omdbId;
   }
 
   public Optional<Long> getUniqueId() {
@@ -77,6 +79,10 @@ public final class EntertainmentItem {
     return actors;
   }
 
+  public String getOmdbId() {
+    return omdbId;
+  }
+
   public static final class Builder {
     private Long uniqueId;
     private String title = "";
@@ -88,10 +94,11 @@ public final class EntertainmentItem {
     private String directors = "";
     private String writers = "";
     private String actors = "";
+    private String omdbId = "";
 
     public EntertainmentItem build() {
       return new EntertainmentItem(Optional.ofNullable(uniqueId), title, description, imageUrl,
-          releaseDate, runtime, genre, directors, writers, actors);
+          releaseDate, runtime, genre, directors, writers, actors, omdbId);
     }
 
     public Builder setUniqueId(Long uniqueId) {
@@ -141,6 +148,11 @@ public final class EntertainmentItem {
 
     public Builder setActors(String actors) {
       this.actors = actors;
+      return this;
+    }
+
+    public Builder setOmdbId(String omdbId) {
+      this.omdbId = omdbId;
       return this;
     }
   }

--- a/src/main/java/com/google/ehub/servlets/DashboardServlet.java
+++ b/src/main/java/com/google/ehub/servlets/DashboardServlet.java
@@ -59,7 +59,7 @@ public class DashboardServlet extends HttpServlet {
       itemList = EntertainmentItemDatastore.getInstance().queryItemsByTitlePrefix(
           fetchOptions, searchValue, sortDir);
     }
-    
+
     response.setContentType("application/json");
     response.getWriter().println(new Gson().toJson(itemList));
   }

--- a/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
+++ b/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
@@ -51,11 +51,13 @@ public class ItemSubmissionServlet extends HttpServlet {
 
     if (!arePostRequestParametersValid(title, description, imageUrl, releaseDate, runtime, genre,
             directors, writers, actors, omdbId)) {
-      System.err.println("ItemSubmissionServlet: Post Request parameters not specified correctly!");
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+          "ItemSubmissionServlet: Post Request parameters not specified correctly!");
       return;
     }
-    if (!isItemUnique(omdbId)) {
-      System.err.println("ItemSubmissionServlet: Item submitted already exists!");
+    if (doesItemExist(omdbId)) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+          "ItemSubmissionServlet: Item submitted already exists!");
       return;
     }
 
@@ -90,7 +92,7 @@ public class ItemSubmissionServlet extends HttpServlet {
     }
 
     response.setContentType("application/json");
-    response.getWriter().println(new Gson().toJson(isItemUnique(omdbId)));
+    response.getWriter().println(new Gson().toJson(!doesItemExist(omdbId)));
   }
 
   /**
@@ -121,7 +123,7 @@ public class ItemSubmissionServlet extends HttpServlet {
     return parameter != null && !parameter.isEmpty() && parameter.length() <= maxLength;
   }
 
-  private static boolean isItemUnique(String omdbId) {
-    return !EntertainmentItemDatastore.getInstance().queryItemByOmdbId(omdbId).isPresent();
+  private static boolean doesItemExist(String omdbId) {
+    return EntertainmentItemDatastore.getInstance().queryItemByOmdbId(omdbId).isPresent();
   }
 }

--- a/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
+++ b/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
@@ -54,6 +54,10 @@ public class ItemSubmissionServlet extends HttpServlet {
       System.err.println("ItemSubmissionServlet: Post Request parameters not specified correctly!");
       return;
     }
+    if (!isItemUnique(omdbId)) {
+      System.err.println("ItemSubmissionServlet: Item submitted already exists!");
+      return;
+    }
 
     EntertainmentItemDatastore.getInstance().addItemToDatastore(new EntertainmentItem.Builder()
                                                                     .setTitle(title)
@@ -69,6 +73,24 @@ public class ItemSubmissionServlet extends HttpServlet {
                                                                     .build());
 
     response.sendRedirect("/index.html");
+  }
+
+  /**
+   * The response of the GET request contains a boolean value that tells whether the item is unique
+   * or not.
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String omdbId = request.getParameter(OMDB_ID_PARAMETER_KEY);
+
+    if (!isParameterValid(omdbId, MAX_CHARS)) {
+      System.err.println(
+          "ItemSubmissionServlet: omdbId parameter given in Get Request is invalid!");
+      return;
+    }
+
+    response.setContentType("application/json");
+    response.getWriter().println(new Gson().toJson(isItemUnique(omdbId)));
   }
 
   /**
@@ -99,22 +121,7 @@ public class ItemSubmissionServlet extends HttpServlet {
     return parameter != null && !parameter.isEmpty() && parameter.length() <= maxLength;
   }
 
-  /**
-   * The response of the GET request contains a boolean value that tells whether the item with the
-   * given omdbId already exists or not.
-   */
-  @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String omdbId = request.getParameter(OMDB_ID_PARAMETER_KEY);
-
-    if (!isParameterValid(omdbId, MAX_CHARS)) {
-      System.err.println(
-          "ItemSubmissionServlet: omdbId parameter given in Get Request is invalid!");
-      return;
-    }
-
-    response.setContentType("application/json");
-    response.getWriter().println(new Gson().toJson(
-        EntertainmentItemDatastore.getInstance().queryItemByOmdbId(omdbId).isPresent()));
+  private static boolean isItemUnique(String omdbId) {
+    return !EntertainmentItemDatastore.getInstance().queryItemByOmdbId(omdbId).isPresent();
   }
 }

--- a/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
+++ b/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
@@ -2,6 +2,7 @@ package com.google.ehub.servlets;
 
 import com.google.ehub.data.EntertainmentItem;
 import com.google.ehub.data.EntertainmentItemDatastore;
+import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Optional;
 import javax.servlet.annotation.WebServlet;
@@ -24,6 +25,7 @@ public class ItemSubmissionServlet extends HttpServlet {
   private static final String DIRECTORS_PARAMETER_KEY = "Director";
   private static final String WRITERS_PARAMETER_KEY = "Writer";
   private static final String ACTORS_PARAMETER_KEY = "Actors";
+  private static final String OMDB_ID_PARAMETER_KEY = "imdbID";
 
   private static final int MAX_TITLE_CHARS = 150;
 
@@ -45,9 +47,10 @@ public class ItemSubmissionServlet extends HttpServlet {
     String directors = request.getParameter(DIRECTORS_PARAMETER_KEY);
     String writers = request.getParameter(WRITERS_PARAMETER_KEY);
     String actors = request.getParameter(ACTORS_PARAMETER_KEY);
+    String omdbId = request.getParameter(OMDB_ID_PARAMETER_KEY);
 
     if (!arePostRequestParametersValid(title, description, imageUrl, releaseDate, runtime, genre,
-            directors, writers, actors)) {
+            directors, writers, actors, omdbId)) {
       System.err.println("ItemSubmissionServlet: Post Request parameters not specified correctly!");
       return;
     }
@@ -62,6 +65,7 @@ public class ItemSubmissionServlet extends HttpServlet {
                                                                     .setDirectors(directors)
                                                                     .setWriters(writers)
                                                                     .setActors(actors)
+                                                                    .setOmdbId(omdbId)
                                                                     .build());
 
     response.sendRedirect("/index.html");
@@ -78,19 +82,39 @@ public class ItemSubmissionServlet extends HttpServlet {
    * @param directors the directors given in the Post request parameter
    * @param writers the writers given in the Post request parameter
    * @param actors the actors given in the Post request parameter
+   * @param omdbId the unique Id used by omdb given in the Post request parameter
    * @return true if the parameters given in the Post request are valid, false otherwise
    */
   private static boolean arePostRequestParametersValid(String title, String description,
       String imageUrl, String releaseDate, String runtime, String genre, String directors,
-      String writers, String actors) {
+      String writers, String actors, String omdbId) {
     return isParameterValid(title, MAX_TITLE_CHARS) && isParameterValid(description, MAX_CHARS)
         && isParameterValid(imageUrl, MAX_CHARS) && isParameterValid(releaseDate, MAX_CHARS)
         && isParameterValid(runtime, MAX_CHARS) && isParameterValid(genre, MAX_CHARS)
         && isParameterValid(directors, MAX_CHARS) && isParameterValid(writers, MAX_CHARS)
-        && isParameterValid(actors, MAX_CHARS);
+        && isParameterValid(actors, MAX_CHARS) && isParameterValid(omdbId, MAX_CHARS);
   }
 
   private static boolean isParameterValid(String parameter, int maxLength) {
     return parameter != null && !parameter.isEmpty() && parameter.length() <= maxLength;
+  }
+
+  /**
+   * The response of the GET request contains a boolean value that tells whether the item with the
+   * given omdbId already exists or not.
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String omdbId = request.getParameter(OMDB_ID_PARAMETER_KEY);
+
+    if (!isParameterValid(omdbId, MAX_CHARS)) {
+      System.err.println(
+          "ItemSubmissionServlet: omdbId parameter given in Get Request is invalid!");
+      return;
+    }
+
+    response.setContentType("application/json");
+    response.getWriter().println(new Gson().toJson(
+        EntertainmentItemDatastore.getInstance().queryItemByOmdbId(omdbId).isPresent()));
   }
 }

--- a/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
+++ b/src/main/java/com/google/ehub/servlets/ItemSubmissionServlet.java
@@ -25,7 +25,7 @@ public class ItemSubmissionServlet extends HttpServlet {
   private static final String DIRECTORS_PARAMETER_KEY = "Director";
   private static final String WRITERS_PARAMETER_KEY = "Writer";
   private static final String ACTORS_PARAMETER_KEY = "Actors";
-  private static final String OMDB_ID_PARAMETER_KEY = "imdbID";
+  private static final String IMDB_ID_PARAMETER_KEY = "imdbID";
 
   private static final int MAX_TITLE_CHARS = 150;
 
@@ -47,7 +47,7 @@ public class ItemSubmissionServlet extends HttpServlet {
     String directors = request.getParameter(DIRECTORS_PARAMETER_KEY);
     String writers = request.getParameter(WRITERS_PARAMETER_KEY);
     String actors = request.getParameter(ACTORS_PARAMETER_KEY);
-    String omdbId = request.getParameter(OMDB_ID_PARAMETER_KEY);
+    String omdbId = request.getParameter(IMDB_ID_PARAMETER_KEY);
 
     if (!arePostRequestParametersValid(title, description, imageUrl, releaseDate, runtime, genre,
             directors, writers, actors, omdbId)) {
@@ -83,7 +83,7 @@ public class ItemSubmissionServlet extends HttpServlet {
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String omdbId = request.getParameter(OMDB_ID_PARAMETER_KEY);
+    String omdbId = request.getParameter(IMDB_ID_PARAMETER_KEY);
 
     if (!isParameterValid(omdbId, MAX_CHARS)) {
       System.err.println(

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -58,7 +58,7 @@
               >
             </select>
             <button
-              type="button"
+              type="submit"
               class="btn btn-light navbar-btn text-nowrap my-sm-0"
               data-toggle="modal"
               data-target="#itemSubmissionDialog"

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -167,6 +167,7 @@ function enableItemSubmissionIfUnique(submitButton, itemCard, omdbItem) {
             submitItem(omdbItem);
           });
         } else {
+          // TODO: Add link to item that already exists.
           itemCard.append($(
               '<p class="card-text">Item already exists on Entertainment Hub!</p>'));
         }

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -45,10 +45,8 @@ function getOmdbItem() {
         } else {
           omdbItemEntry.append(createOmdbItemCard(omdbItem));
 
-          submitButton.removeClass('d-none');
-          submitButton.click(() => {
-            submitItem(omdbItem);
-          });
+          enableItemSubmissionIfNotDuplicate(
+              submitButton, omdbItemEntry, omdbItem);
         }
       })
       .catch((error) => {
@@ -150,6 +148,33 @@ function createOmdbItemCard(omdbItem) {
   card.append(cardBody);
 
   return card;
+}
+
+/**
+ * Makes the item submission button visible if the item is not a duplicate.
+ *
+ * @param { jQuery } submitButton - button used to submit omdb items
+ * @param { jQuery } omdbItemEntry - div that displays info about the item found
+ * @param { JSON } omdbItem - the item found by omdb API
+ */
+function enableItemSubmissionIfNotDuplicate(
+    submitButton, omdbItemEntry, omdbItem) {
+  fetch('/item-submission?imdbID=' + omdbItem.imdbId)
+      .then((response) => response.json())
+      .then((isDuplicateItem) => {
+        if (isDuplicateItem) {
+          omdbItemEntry.append(
+              $('<p>Item already exists on Entertainment Hub!</p>'));
+        } else {
+          submitButton.removeClass('d-none');
+          submitButton.click(() => {
+            submitItem(omdbItem);
+          });
+        }
+      })
+      .catch((error) => {
+        console.log('failed to check if omdb Item is duplicate: ' + error);
+      });
 }
 
 /**

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -36,17 +36,17 @@ function getOmdbItem() {
         omdbItemEntry.empty();
 
         const submitButton = $('#submitButton');
-        submitButton.off('click');
 
         if (omdbItem.Response === 'False') {
           omdbItemEntry.append($('<p>Item not found!</p>'));
 
           submitButton.addClass('d-none');
         } else {
-          omdbItemEntry.append(createOmdbItemCard(omdbItem));
+          const itemCard = createOmdbItemCard(omdbItem);
 
-          enableItemSubmissionIfNotDuplicate(
-              submitButton, omdbItemEntry, omdbItem);
+          omdbItemEntry.append(itemCard);
+
+          enableItemSubmissionIfUnique(submitButton, itemCard, omdbItem);
         }
       })
       .catch((error) => {
@@ -154,22 +154,21 @@ function createOmdbItemCard(omdbItem) {
  * Makes the item submission button visible if the item is not a duplicate.
  *
  * @param { jQuery } submitButton - button used to submit omdb items
- * @param { jQuery } omdbItemEntry - div that displays info about the item found
+ * @param { jQuery } itemCard - card div that displays info about the item found
  * @param { JSON } omdbItem - the item found by omdb API
  */
-function enableItemSubmissionIfNotDuplicate(
-    submitButton, omdbItemEntry, omdbItem) {
-  fetch('/item-submission?imdbID=' + omdbItem.imdbId)
+function enableItemSubmissionIfUnique(submitButton, itemCard, omdbItem) {
+  fetch('/item-submission?imdbID=' + omdbItem.imdbID)
       .then((response) => response.json())
-      .then((isDuplicateItem) => {
-        if (isDuplicateItem) {
-          omdbItemEntry.append(
-              $('<p>Item already exists on Entertainment Hub!</p>'));
-        } else {
+      .then((isItemUnique) => {
+        if (isItemUnique) {
           submitButton.removeClass('d-none');
-          submitButton.click(() => {
+          submitButton.off().one('click', () => {
             submitItem(omdbItem);
           });
+        } else {
+          itemCard.append($(
+              '<p class="card-text">Item already exists on Entertainment Hub!</p>'));
         }
       })
       .catch((error) => {

--- a/src/test/java/com/google/ehub/data/EntertainmentItemDatastoreTest.java
+++ b/src/test/java/com/google/ehub/data/EntertainmentItemDatastoreTest.java
@@ -31,6 +31,7 @@ public class EntertainmentItemDatastoreTest {
   private static final String DIRECTORS_PROPERTY_KEY = "directors";
   private static final String WRITERS_PROPERTY_KEY = "writers";
   private static final String ACTORS_PROPERTY_KEY = "actors";
+  private static final String OMDB_ID_PARAMETER_KEY = "omdbId";
 
   private static final String[] TITLES_IN_ASCENDING_ORDER = {
       "Avengers", "Nemo", "Shrek", "Star Wars", "Transformers"};
@@ -43,6 +44,7 @@ public class EntertainmentItemDatastoreTest {
   private static final String DIRECTORS = "George Lucas";
   private static final String WRITERS = "George Lucas";
   private static final String ACTORS = "Mark Hamill, Harrison Ford";
+  private static final String OMDB_ID = "tt23113212";
 
   private final EntertainmentItemDatastore entertainmentItemDatastore =
       EntertainmentItemDatastore.getInstance();
@@ -72,6 +74,7 @@ public class EntertainmentItemDatastoreTest {
                                                       .setDirectors(DIRECTORS)
                                                       .setWriters(WRITERS)
                                                       .setActors(ACTORS)
+                                                      .setOmdbId(OMDB_ID)
                                                       .build());
 
     Query query = new Query(ENTERTAINMENT_ITEM_KIND);
@@ -91,6 +94,7 @@ public class EntertainmentItemDatastoreTest {
     Assert.assertEquals(DIRECTORS, entityList.get(0).getProperty(DIRECTORS_PROPERTY_KEY));
     Assert.assertEquals(WRITERS, entityList.get(0).getProperty(WRITERS_PROPERTY_KEY));
     Assert.assertEquals(ACTORS, entityList.get(0).getProperty(ACTORS_PROPERTY_KEY));
+    Assert.assertEquals(OMDB_ID, entityList.get(0).getProperty(OMDB_ID_PARAMETER_KEY));
   }
 
   @Test

--- a/src/test/java/com/google/ehub/servlets/DashboardServletTest.java
+++ b/src/test/java/com/google/ehub/servlets/DashboardServletTest.java
@@ -50,6 +50,7 @@ public class DashboardServletTest {
   private static final String DIRECTORS_PROPERTY_KEY = "directors";
   private static final String WRITERS_PROPERTY_KEY = "writers";
   private static final String ACTORS_PROPERTY_KEY = "actors";
+  private static final String OMDB_ID_PROPERTY_KEY = "omdbId";
 
   private static final String TITLE = "Star Wars";
   private static final String DESCRIPTION = "Blah....";
@@ -60,6 +61,7 @@ public class DashboardServletTest {
   private static final String DIRECTORS = "George Lucas";
   private static final String WRITERS = "George Lucas";
   private static final String ACTORS = "Mark Hamill, Harrison Ford";
+  private static final String OMDB_ID = "tt23113212";
 
   private static final int PAGE_SIZE = 18;
   private static final int MAX_SEARCH_VALUE_CHARS = 150;
@@ -118,6 +120,7 @@ public class DashboardServletTest {
     itemEntity.setProperty(DIRECTORS_PROPERTY_KEY, DIRECTORS);
     itemEntity.setProperty(WRITERS_PROPERTY_KEY, WRITERS);
     itemEntity.setProperty(ACTORS_PROPERTY_KEY, ACTORS);
+    itemEntity.setProperty(OMDB_ID_PROPERTY_KEY, OMDB_ID);
 
     DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
     datastoreService.put(itemEntity);

--- a/src/test/java/com/google/ehub/servlets/ItemSubmissionServletTest.java
+++ b/src/test/java/com/google/ehub/servlets/ItemSubmissionServletTest.java
@@ -1,12 +1,17 @@
 package com.google.ehub.servlets;
 
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.ehub.data.EntertainmentItem;
 import com.google.ehub.data.EntertainmentItemDatastore;
+import com.google.gson.Gson;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Arrays;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -49,11 +54,14 @@ public class ItemSubmissionServletTest {
   private static final String ACTORS = "Mark Hamill, Harrison Ford";
   private static final String OMDB_ID = "tt23113212";
 
+  private static final String JSON_CONTENT_TYPE = "application/json";
+
   private static final int MAX_TITLE_CHARS = 150;
   private static final int MAX_CHARS = 500;
 
   @Mock HttpServletRequest request;
   @Mock HttpServletResponse response;
+  @Mock PrintWriter printWriter;
 
   @Before
   public void init() {
@@ -191,6 +199,93 @@ public class ItemSubmissionServletTest {
         entertainmentItemDatastore.queryAllItems(FetchOptions.Builder.withDefaults())
             .getItems()
             .size());
+  }
+
+  @Test
+  public void postRequestWithDuplicateItem_NoItemIsAdded() throws IOException {
+    entertainmentItemDatastore.addItemToDatastore(new EntertainmentItem.Builder()
+                                                      .setTitle(TITLE)
+                                                      .setDescription(DESCRIPTION)
+                                                      .setImageUrl(IMAGE_URL)
+                                                      .setReleaseDate(RELEASE_DATE)
+                                                      .setRuntime(RUNTIME)
+                                                      .setGenre(GENRE)
+                                                      .setDirectors(DIRECTORS)
+                                                      .setWriters(WRITERS)
+                                                      .setActors(ACTORS)
+                                                      .setOmdbId(OMDB_ID)
+                                                      .build());
+
+    when(request.getParameter(TITLE_PARAMETER_KEY)).thenReturn(TITLE);
+    when(request.getParameter(DESCRIPTION_PARAMETER_KEY)).thenReturn(DESCRIPTION);
+    when(request.getParameter(IMAGE_URL_PARAMETER_KEY)).thenReturn(IMAGE_URL);
+    when(request.getParameter(RELEASE_DATE_PARAMETER_KEY)).thenReturn(RELEASE_DATE);
+    when(request.getParameter(RUNTIME_PARAMETER_KEY)).thenReturn(RUNTIME);
+    when(request.getParameter(GENRE_PARAMETER_KEY)).thenReturn(GENRE);
+    when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
+    when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
+    when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+
+    servlet.doPost(request, response);
+
+    Assert.assertEquals(1,
+        entertainmentItemDatastore.queryAllItems(FetchOptions.Builder.withDefaults())
+            .getItems()
+            .size());
+  }
+
+  @Test
+  public void getRequestWithNullParam_NoResponseIsSent() throws IOException {
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(null);
+
+    servlet.doGet(request, response);
+
+    verify(response, never()).setContentType(JSON_CONTENT_TYPE);
+  }
+
+  @Test
+  public void getRequestWithEmptyParam_NoResponseIsSent() throws IOException {
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn("");
+
+    servlet.doGet(request, response);
+
+    verify(response, never()).setContentType(JSON_CONTENT_TYPE);
+  }
+
+  @Test
+  public void getRequestWithUniqueItem_ResponseReturnsItemIsUnique() throws IOException {
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(response.getWriter()).thenReturn(printWriter);
+
+    servlet.doGet(request, response);
+
+    verify(response).setContentType(JSON_CONTENT_TYPE);
+    verify(printWriter).println(new Gson().toJson(/* isItemUnique */ true));
+  }
+
+  @Test
+  public void getRequestWithDuplicateItem_ResponseReturnsItemIsNotUnique() throws IOException {
+    entertainmentItemDatastore.addItemToDatastore(new EntertainmentItem.Builder()
+                                                      .setTitle(TITLE)
+                                                      .setDescription(DESCRIPTION)
+                                                      .setImageUrl(IMAGE_URL)
+                                                      .setReleaseDate(RELEASE_DATE)
+                                                      .setRuntime(RUNTIME)
+                                                      .setGenre(GENRE)
+                                                      .setDirectors(DIRECTORS)
+                                                      .setWriters(WRITERS)
+                                                      .setActors(ACTORS)
+                                                      .setOmdbId(OMDB_ID)
+                                                      .build());
+
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(response.getWriter()).thenReturn(printWriter);
+
+    servlet.doGet(request, response);
+
+    verify(response).setContentType(JSON_CONTENT_TYPE);
+    verify(printWriter).println(new Gson().toJson(/* isItemUnique */ false));
   }
 
   private static String getStringOfLength(int characterLength) {

--- a/src/test/java/com/google/ehub/servlets/ItemSubmissionServletTest.java
+++ b/src/test/java/com/google/ehub/servlets/ItemSubmissionServletTest.java
@@ -41,7 +41,7 @@ public class ItemSubmissionServletTest {
   private static final String DIRECTORS_PARAMETER_KEY = "Director";
   private static final String WRITERS_PARAMETER_KEY = "Writer";
   private static final String ACTORS_PARAMETER_KEY = "Actors";
-  private static final String OMDB_ID_PARAMETER_KEY = "imdbID";
+  private static final String IMDB_ID_PARAMETER_KEY = "imdbID";
 
   private static final String TITLE = "Star Wars";
   private static final String DESCRIPTION = "Blah....";
@@ -85,7 +85,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(null);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(null);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(null);
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(null);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(null);
 
     servlet.doPost(request, response);
 
@@ -106,7 +106,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -127,7 +127,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn("");
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn("");
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn("");
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn("");
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn("");
 
     servlet.doPost(request, response);
 
@@ -149,7 +149,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -170,7 +170,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(getStringOfLength(MAX_CHARS));
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(getStringOfLength(MAX_CHARS));
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(getStringOfLength(MAX_CHARS));
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -191,7 +191,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -225,7 +225,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -237,7 +237,7 @@ public class ItemSubmissionServletTest {
 
   @Test
   public void getRequestWithNullParam_NoResponseIsSent() throws IOException {
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(null);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(null);
 
     servlet.doGet(request, response);
 
@@ -246,7 +246,7 @@ public class ItemSubmissionServletTest {
 
   @Test
   public void getRequestWithEmptyParam_NoResponseIsSent() throws IOException {
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn("");
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn("");
 
     servlet.doGet(request, response);
 
@@ -255,7 +255,7 @@ public class ItemSubmissionServletTest {
 
   @Test
   public void getRequestWithUniqueItem_ResponseReturnsItemIsUnique() throws IOException {
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
     when(response.getWriter()).thenReturn(printWriter);
 
     servlet.doGet(request, response);
@@ -279,7 +279,7 @@ public class ItemSubmissionServletTest {
                                                       .setOmdbId(OMDB_ID)
                                                       .build());
 
-    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
+    when(request.getParameter(IMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
     when(response.getWriter()).thenReturn(printWriter);
 
     servlet.doGet(request, response);

--- a/src/test/java/com/google/ehub/servlets/ItemSubmissionServletTest.java
+++ b/src/test/java/com/google/ehub/servlets/ItemSubmissionServletTest.java
@@ -36,6 +36,7 @@ public class ItemSubmissionServletTest {
   private static final String DIRECTORS_PARAMETER_KEY = "Director";
   private static final String WRITERS_PARAMETER_KEY = "Writer";
   private static final String ACTORS_PARAMETER_KEY = "Actors";
+  private static final String OMDB_ID_PARAMETER_KEY = "imdbID";
 
   private static final String TITLE = "Star Wars";
   private static final String DESCRIPTION = "Blah....";
@@ -46,6 +47,7 @@ public class ItemSubmissionServletTest {
   private static final String DIRECTORS = "George Lucas";
   private static final String WRITERS = "George Lucas";
   private static final String ACTORS = "Mark Hamill, Harrison Ford";
+  private static final String OMDB_ID = "tt23113212";
 
   private static final int MAX_TITLE_CHARS = 150;
   private static final int MAX_CHARS = 500;
@@ -75,6 +77,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(null);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(null);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(null);
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(null);
 
     servlet.doPost(request, response);
 
@@ -95,6 +98,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -115,6 +119,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn("");
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn("");
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn("");
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn("");
 
     servlet.doPost(request, response);
 
@@ -136,6 +141,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -156,6 +162,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(getStringOfLength(MAX_CHARS));
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(getStringOfLength(MAX_CHARS));
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(getStringOfLength(MAX_CHARS));
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 
@@ -176,6 +183,7 @@ public class ItemSubmissionServletTest {
     when(request.getParameter(DIRECTORS_PARAMETER_KEY)).thenReturn(DIRECTORS);
     when(request.getParameter(WRITERS_PARAMETER_KEY)).thenReturn(WRITERS);
     when(request.getParameter(ACTORS_PARAMETER_KEY)).thenReturn(ACTORS);
+    when(request.getParameter(OMDB_ID_PARAMETER_KEY)).thenReturn(OMDB_ID);
 
     servlet.doPost(request, response);
 


### PR DESCRIPTION
The ItemSubmissionServlet wasn't checking if the item being submitted already exists on Datastore, making it possible for users to submit duplicate items. To address this issue, I added a unique property(omdbId) to the EntertainmentItem class to be able to check if the item already exists or not.