### PR TITLE
Fix bracket error that caused script.js to fail

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -311,7 +311,6 @@ function enableItemSubmissionIfUnique(submitButton, itemCard, omdbItem) {
         itemCard.append($(
           '<p class="card-text">Item already exists on Entertainment Hub!' +
           itemLink + '</p>'));
-      }
     })
     .catch((error) => {
       console.log('failed to check if omdb Item is duplicate: ' + error);


### PR DESCRIPTION
The file script.js had an extra bracket after Oyin solved a merge conflict. This was causing the website to stop loading.