### PR TITLE
Add index.yaml file for datastore queries

### DIFF
--- a/src/main/webapp/WEB-INF/index.yaml
+++ b/src/main/webapp/WEB-INF/index.yaml
@@ -1,0 +1,6 @@
+indexes:
+
+- kind: comment
+  properties:
+  - name: itemId
+  - name: timestampMillis


### PR DESCRIPTION
Kept getting on the deployed site: com.google.appengine.api.datastore.DatastoreNeedIndexException: no matching index found.

Instructions to add an index: https://cloud.google.com/datastore/docs/tools/indexconfig