### PR TITLE
Improve user profile UI, fix username text overlap error, and fix favorite item grid on mobile

### DIFF
--- a/src/main/webapp/ProfilePage.html
+++ b/src/main/webapp/ProfilePage.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>My Profile Page</title>
+    <title>Entertainment Hub - My Profile Page</title>
     <meta charset="UTF-8" />
     <meta
       name="viewport"
@@ -25,7 +25,7 @@
     <div id="navbar"></div>
     <div class="container">
       <h1 class="text-center">My Profile Page</h1>
-      <div class="card mb-3" style="max-width: 1000px; margin: 0 auto;">
+      <div class="card bg-light mb-3 w-100">
         <div class="row no-gutters">
           <div class="col-md-4">
             <img id="avatar" src="" class="card-img-top" alt="profile avatar" />
@@ -35,31 +35,27 @@
               <h5 class="card-title" id="name"></h5>
               <h6 class="card-subtitle mb-2" id="username"></h6>
               <p class="card-text" id="bio"></p>
+              <button
+                id="edit"
+                class="btn btn-success"
+                onclick="location.href = '/EditProfilePage.html';"
+              >
+                Edit Profile
+              </button>
             </div>
           </div>
         </div>
-        <button
-          id="edit"
-          class="btn btn-info"
-          onclick="location.href = '/EditProfilePage.html';"
-        >
-          Edit Profile
-        </button>
-
-        <div class="mt-3">
-          <h2 class="text-center">Favorite Items</h2>
-          <div
-            style="width: 45em; margin: 0 auto;"
-            style="height: 10rem;"
-          >
-            <div id="item-container"></div>
-          </div>
-          <h2 class="text-center mt-3">Recommended Users</h2>
-          <h5 class="text-center text-secondary">(Based on shared amount of likes)</h5>
-          <div class="horizontal-scrollable my-3" id="recommendedUsersContainer">
-          </div>
-        </div>
       </div>
+      <h2 class="text-center mt-3">Favorite Items</h2>
+      <div id="item-container"></div>
+      <h2 class="text-center mt-3">Recommended Users</h2>
+      <h5 class="text-center text-secondary">
+        (Based on shared amount of likes)
+      </h5>
+      <div
+        class="horizontal-scrollable my-3"
+        id="recommendedUsersContainer"
+      ></div>
     </div>
   </body>
 </html>

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -23,6 +23,11 @@ hidden {
   float: none; 
 } 
 
+#user-card {
+  width: 250px;
+  max-width: 250px;
+}
+
 ul {
   list-style-type: none;
 }

--- a/src/main/webapp/user-profile-page.html
+++ b/src/main/webapp/user-profile-page.html
@@ -23,7 +23,7 @@
     <div id="navbar"></div>
     <div class="container">
       <h1 class="text-center">User Profile Page</h1>
-      <div class="card mb-3" style="max-width: 1000px; margin: 0 auto;">
+      <div class="card bg-light mb-3 w-100">
         <div class="row no-gutters">
           <div class="col-md-4">
             <img id="avatar" src="" class="card-img-top" alt="profile avatar" />
@@ -35,13 +35,9 @@
             </div>
           </div>
         </div>
-        <div class="mt-3">
-          <h2 class="text-center">Favorite Items</h2>
-          <div style="width: 45em; margin: 0 auto;" style="height: 10rem;">
-            <div id="item-container"></div>
-          </div>
-        </div>
       </div>
+      <h2 class="text-center mt-3">Favorite Items</h2>
+      <div id="item-container"></div>
     </div>
   </body>
 </html>

--- a/src/main/webapp/user_script.js
+++ b/src/main/webapp/user_script.js
@@ -70,7 +70,8 @@ function loadUserProfilePage() {
  * Fetches the items that were liked by user and sends the array to
  * populate the page with the item cards.
  *
- * @param { string } userEmail - the email linked to the favorite items to display
+ * @param { string } userEmail - the email linked to the favorite items to
+ *     display
  */
 function loadFavItems(userEmail) {
   fetch('/favorite-item?email=' + userEmail)
@@ -94,13 +95,13 @@ function populateFavoriteItemGrid(favoriteItems) {
   let currItemIndex = 0;
 
   while (currItemIndex < favoriteItems.length) {
-    const rowElem = $('<div class="row"></div>');
+    const rowElem = $('<div class="row mb-3"></div>');
 
     for (let cell = 0;
          cell < MAX_CELLS_PER_ROW && currItemIndex < favoriteItems.length;
          cell++, currItemIndex++) {
       const item = favoriteItems[currItemIndex];
-      const colElem = $('<div class="col-6 col-md-4"></div>');
+      const colElem = $('<div class="col-md-4"></div>');
 
       fetch(`/itempagedata?itemId=${item}`)
           .then((response) => response.json())
@@ -130,7 +131,7 @@ function createFavoriteItemCard(entertainmentItem) {
 
   const cardBody = $('<div class="card-body"></div>');
   cardBody.append(
-      $('<h5 class="card-title">' + entertainmentItem.title + '(' +
+      $('<h5 class="card-title">' + entertainmentItem.title + ' (' +
         entertainmentItem.releaseDate + ')' +
         '</h5>'));
   card.append(cardBody);
@@ -154,7 +155,7 @@ function loadRecommendedUsers(recommendedUsers) {
     return;
   }
 
-  const usersRow = $('<div class="row"></div>');
+  const usersRow = $('<div class="row"</div>')
   usersContainer.append(usersRow);
 
   recommendedUsers.forEach((email) => {
@@ -179,7 +180,7 @@ function loadRecommendedUsers(recommendedUsers) {
  * @returns { jQuery } card element representing the user
  */
 function createProfileCard(profile) {
-  const card = $('<div class="card bg-light"></div>');
+  const card = $('<div class="card bg-light" id="user-card"></div>');
   card.append(
       $('<img class="card-img-top" src="' +
         getProfileImageUrl(profile.username) + '">'));
@@ -189,7 +190,8 @@ function createProfileCard(profile) {
 
   const cardBody = $('<div class="card-body"></div>');
   cardBody.append(
-      $('<h5 class="card-title text-center">' + profile.username + '</h5>'));
+      $('<h5 class="card-title text-center text-wrap">' + profile.username +
+        '</h5>'));
 
   card.append(cardBody);
 


### PR DESCRIPTION
The logged in user profile page looks like this:

![NewProfilePage](https://user-images.githubusercontent.com/26044298/88555523-f0ac9200-cff5-11ea-9c1e-1ff7a5ae4722.png)

The username past the card issue was fixed:
![FixUsernamePastCard](https://user-images.githubusercontent.com/26044298/88555807-441ee000-cff6-11ea-88b2-63e24cd4dfe8.png)

Other user profile looks like this:
![OtherUserProfile](https://user-images.githubusercontent.com/26044298/88555934-6b75ad00-cff6-11ea-8b4e-aea4e86457b5.png)

This changes also make the favorite item grid look a lot better on mobile and makes the page more mobile friendly.