### PR TITLE
Add links to user profiles from the item page comments

### DIFF
--- a/src/main/webapp/item-page.html
+++ b/src/main/webapp/item-page.html
@@ -11,12 +11,12 @@
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
     />
-    <link rel="stylesheet" href="style.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
     />
     <link rel="stylesheet" href="theme.css" />
+    <link rel="stylesheet" href="style.css" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
@@ -27,7 +27,7 @@
   <body onload="loadItemPage()">
     <div id="navbar"></div>
     <div class="container">
-      <div class="row row justify-content-center">
+      <div class="row justify-content-center">
         <div class="col-md-5" id="item-container"></div>
       </div>
       <h2 class="mt-3">Comments</h2>

--- a/src/main/webapp/itempagescript.js
+++ b/src/main/webapp/itempagescript.js
@@ -118,7 +118,7 @@ function submitComment() {
 function getItemPageComments(comments) {
   const commentContainer = $('#comment-container');
   comments.forEach((comment) => {
-    commentContainer.append(createListElement(comment));
+    commentContainer.append(createCommentElement(comment));
   });
 }
 
@@ -139,35 +139,95 @@ function deleteComment(commentElem, commentId) {
 }
 
 /**
- * Creates list element from given comment
+ * Creates list element displaying comment information
  *
  * @param { JSON } comment - the comment whose data is displayed on the list
  *     element
  * @returns { jQuery }  returns a list element
  */
-function createListElement(comment) {
-  const liElement = $('<li class="list-group-item"></li>');
-  const date = new Date(comment.timestampMillis);
+function createCommentElement(comment) {
+  const commentElem = $('<li class="list-group-item border"></li>');
 
-  liElement.text(
-      comment.username + ': ' + comment.comment + ' - ' +
-      '(' + date.toLocaleString() + ')');
+  const commentHeader = $('<div class="row no-gutters my-1"></div>');
+  commentElem.append(commentHeader);
 
-  liElement.append(
-      $('<img class="pr-1" src="' + getProfileImageUrl(comment.email) +
-        '.png?s=23' + '"style=float:left;"></img>'));
+  const userUrl = '/user-profile-page.html?username=' + comment.username;
+
+  commentHeader.append(createUserAvatar(comment.email, userUrl));
+  commentHeader.append(createUsernameText(comment.username, userUrl));
+  commentHeader.append(createCommentDate(comment.timestampMillis));
+
+  commentElem.append($('<p>' + comment.comment + '</p>'));
 
   if (comment.belongsToUser) {
-    const deleteButton =
-        $('<div><i class="fa fa-trash" style="float:right;"></i></div>');
-    deleteButton.one('click', () => {
-      deleteComment(liElement, comment.commentId);
-    });
-    
-    liElement.append(deleteButton);
+    commentElem.append(
+        createDeleteCommentButton(commentElem, comment.commentId));
   }
 
-  return liElement;
+  return commentElem;
+}
+
+/**
+ * Creates image div that displays avatar used in comment.
+ *
+ * @param { string } email - the email used to create the avatar for the comment
+ * @param { string } userUrl - the url that links to the user's profile
+ * @returns { jQuery } image div displaying avatar
+ */
+function createUserAvatar(email, userUrl) {
+  const userAvatar =
+      $('<img class="col-md-auto mr-2" src="' + getProfileImageUrl(email) +
+        '" width="24" height="24">');
+  userAvatar.click(function() {
+    window.location.href = userUrl;
+  });
+
+  return userAvatar;
+}
+
+/**
+ * Creates text div that displays the username that posted a comment
+ *
+ * @param { string } username - the username that posted the comment
+ * @param { string } userUrl - the url that links to the user's profile
+ * @returns { jQuery } text div displaying the username that posted a comment
+ */
+function createUsernameText(username, userUrl) {
+  const usernameText = $('<p class="col-md-auto mr-2">' + username + '</p>');
+  usernameText.append(
+      $('<a class="stretched-link" href="' + userUrl + '"></a>'));
+
+  return usernameText;
+}
+
+/**
+ * Creates text div to display the date of the comment.
+ *
+ * @param { number } timestampMillis - the timestamp when the comment was posted
+ * @returns { jQuery } text div displaying comment date
+ */
+function createCommentDate(timestampMillis) {
+  const date = new Date(timestampMillis);
+  const dateText =
+      $('<p class="col-md-auto">(' + date.toLocaleString() + ')</p>');
+
+  return dateText;
+}
+
+/**
+ * Creates the button used to delete a comment by the user who owns it.
+ * @param { jQuery } commentElem - div that contains comment
+ * @param { number } commentId - unique Id used to identify the comment
+ * @returns { jQuery } button used to delete comment
+ */
+function createDeleteCommentButton(commentElem, commentId) {
+  const deleteButton =
+      $('<div><i class="fa fa-trash" style="float:right;"></i></div>');
+  deleteButton.one('click', () => {
+    deleteComment(commentElem, commentId);
+  });
+
+  return deleteButton;
 }
 
 /**

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -28,9 +28,10 @@ hidden {
   max-width: 250px;
 }
 
-ul {
-  list-style-type: none;
+.list-group-item {
+   word-wrap: break-word; 
 }
+
 .selector-for-some-widget {
   box-sizing: content-box;
 }

--- a/src/main/webapp/user_script.js
+++ b/src/main/webapp/user_script.js
@@ -130,7 +130,7 @@ function createFavoriteItemCard(entertainmentItem) {
 
   const cardBody = $('<div class="card-body"></div>');
   cardBody.append(
-      $('<h5 class="card-title">' + entertainmentItem.title + ' (' +
+      $('<h5 class="card-title text-center">' + entertainmentItem.title + ' (' +
         entertainmentItem.releaseDate + ')' +
         '</h5>'));
   card.append(cardBody);


### PR DESCRIPTION
Here is how the comments look now:

![Screenshot 2020-08-04 at 10 01 45 AM](https://user-images.githubusercontent.com/26044298/89306356-c08c7100-d63d-11ea-8d54-044b9c24496f.png)

With this changes there is now a clickable link for the username and the avatar icon that redirects to the user profile page.